### PR TITLE
Rasterization

### DIFF
--- a/src/tred/graph.py
+++ b/src/tred/graph.py
@@ -132,8 +132,9 @@ class Raster(nn.Module):
         constant(self, 'velocity', velocity)
         constant(self, 'grid_spacing', grid_spacing)
         constant(self, 'nsigma', nsigma)
+
         self._pdims = pdims or ()
-        self._tdim = tdim
+        self._tdim = tdim if tdim>=0 else len(self._pdims) + 1 + tdim
 
     def _time_diff(self, tail, head=None):
         """
@@ -162,6 +163,10 @@ class Raster(nn.Module):
         if self._pdims:
             old_tdim = (set(range(ndims)) - set(self._pdims)).pop()
             axes = list(iter(self._pdims))
+            # Method insert always inserts new elements in front of the position;
+            # Insertion position is desired when tdim >= 0;
+            # For tdim < 0, data fall behind the desired position counting from the back;
+            # A correction is made in __init__; vdim + tdim for tdim<0
             axes.insert(self._tdim, old_tdim)
             point = point[:, axes]
 

--- a/src/tred/graph.py
+++ b/src/tred/graph.py
@@ -26,6 +26,7 @@ from .blocking import Block
 from .drift import drift
 from .util import debug, tenstr
 from .raster.depos import binned as raster_depos
+from .raster.steps import compute_qeff
 
 from .types import index_dtype
 from .sparse import chunkify
@@ -36,9 +37,18 @@ import torch
 import torch.nn as nn
 
 def raster_steps(*args,**kwds):
-    raise NotImplementedError("Yousen, make raster.steps.function, import it as tred.graph.raster_steps and delete this temporary function")
-
-
+    # raise NotImplementedError("Yousen, make raster.steps.function, import it as tred.graph.raster_steps and delete this temporary function")
+    # rasters, offsets = raster_steps(self.grid_spacing, tail, head, sigma, charge, nsigma=self.nsigma)
+    # args[0] : grid_spaing
+    # args[1] : tail, X0
+    # args[2] : tail, X1
+    # args[3] : sigma
+    # args[4] : charge, Q
+    # kwds['nsigma] : nsigma, scalar
+    return compute_qeff(grid_spacing=args[0], X0=args[1], X1=args[2],
+                        Sigma=args[3], Q=args[4],
+                        n_sigma=(kwds['nsigma'], kwds['nsigma'], kwds['nsigma']),
+                        origin=(0,0,0), method='gauss_legendre', npoints=(2,2,2))
 
 def param(thing, dtype=torch.float32):
     if isinstance(thing, torch.Tensor):
@@ -158,6 +168,7 @@ class Raster(nn.Module):
 
         head = self._transform(head, time)
         rasters, offsets = raster_steps(self.grid_spacing, tail, head, sigma, charge, nsigma=self.nsigma)
+
         return Block(location = offsets, data=rasters)
 
 

--- a/src/tred/io_nd.py
+++ b/src/tred/io_nd.py
@@ -1,0 +1,360 @@
+'''
+For usage of DataLoader in PyTorch, check https://github.com/pytorch/pytorch/issues/71872
+'''
+
+import yaml
+from collections import defaultdict
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset, Sampler, BatchSampler
+
+from tred.types import index_dtype
+from tred.types import index_dtype
+from tred.units import cm, mm
+
+from importlib import reload  # Python 3.4+
+import tred.loaders
+
+def simple_geo_parser(det_yaml, tile_yaml):
+    '''
+    FIXME: slight difference between GDML and YAMLs
+
+    FIXME: output is in units of cm.
+    FIXME: consistent usage of units
+    '''
+    with open(det_yaml, 'r') as f:
+        detprop = yaml.safe_load(f)
+    with open(tile_yaml, 'r') as f:
+        tile_layout = yaml.safe_load(f)
+            
+    PIXEL_PITCH = tile_layout['pixel_pitch'] * mm / cm
+    chip_channel_to_position = tile_layout['chip_channel_to_position']
+
+    TILE_BORDERS = np.zeros((2,2))
+
+    zs = np.array(list(chip_channel_to_position.values()))[:,0] * PIXEL_PITCH
+    ys = np.array(list(chip_channel_to_position.values()))[:,1] * PIXEL_PITCH
+    TILE_BORDERS[0] = [-(max(zs) + PIXEL_PITCH)/2, (max(zs) + PIXEL_PITCH)/2]
+    TILE_BORDERS[1] = [-(max(ys) + PIXEL_PITCH)/2, (max(ys) + PIXEL_PITCH)/2]
+
+    tile_indeces = tile_layout['tile_indeces']
+    TILE_POSITIONS = tile_layout['tile_positions']
+    tpc_ids = np.unique(np.array(list(tile_indeces.values()))[:,0], axis=0)
+
+    anodes = defaultdict(list)
+    for tpc_id in tpc_ids:
+        for tile in tile_indeces:
+            if tile_indeces[tile][0] == tpc_id:
+                anodes[tpc_id].append(TILE_POSITIONS[tile])
+
+    DRIFT_LENGTH = detprop['drift_length']
+
+    TPC_OFFSETS = np.array(detprop['tpc_offsets'])
+
+    TPC_BORDERS = np.empty((TPC_OFFSETS.shape[0] * tpc_ids.shape[0], 3, 2))
+
+    for it, tpc_offset in enumerate(TPC_OFFSETS):
+        for ia, anode in enumerate(anodes):
+            tiles = np.vstack(anodes[anode]) * mm /cm
+            drift_direction = 1 if anode == 1 else -1
+            z_border = min(tiles[:,2]) + TILE_BORDERS[0][0] + tpc_offset[2], \
+                       max(tiles[:,2]) + TILE_BORDERS[0][1] + tpc_offset[2]
+            y_border = min(tiles[:,1]) + TILE_BORDERS[1][0] + tpc_offset[1], \
+                       max(tiles[:,1]) + TILE_BORDERS[1][1] + tpc_offset[1]
+            # first dimension of tiles is fixed, 0->-46.788cm, 1->46.788cm
+            x_border = min(tiles[:,0]) + tpc_offset[0], \
+                       max(tiles[:,0]) + DRIFT_LENGTH * drift_direction + tpc_offset[0]
+            TPC_BORDERS[it*2+ia] = (x_border, y_border, z_border)
+    return torch.tensor(TPC_BORDERS, requires_grad=False)
+
+def tpc_label(borders, X0, X1=None, **kwargs):
+    '''
+    Args:
+        borders: tensor, in a shape of (N_batch, 3, 2),
+                 the second dimension for (x, y, z) in order,
+                the third dimension is for min or max, without sorting.
+        X0: Tensor[float32]
+        X1: Tensor[float32] (optional)
+        Keyword args:
+            - 'nchunk': int, number of TPCs in parallel when selecting segments
+    return:
+        labels of tpc, tensor, (N_batch,)
+
+    Pre-requisites: there is no overlaps between TPC volumes and steps.
+    '''
+    labels = torch.full((len(X0),), len(borders), dtype=index_dtype)
+
+    nchunk =  kwargs.get('nchunk', 10)
+    X0cs = torch.chunk(X0, nchunk)
+    if X1 != None:
+        X1cs = torch.chunk(X1, nchunk)
+    else:
+        X1cs = [None] * len(X0cs)
+
+    labels = []
+    
+    boxes = borders
+    vmin = torch.min(boxes, dim=2)[0] # (ntpc, 3)
+    vmax = torch.max(boxes, dim=2)[0] # (ntpc, 3)
+    
+    for X0c, X1c in zip(X0cs, X1cs):
+        labelc = torch.full((len(X0c),), -1, dtype=index_dtype)
+        if X1c is None:
+            X = X0c
+        else:
+            X = (X0c + X1c)/2
+
+        c0 = torch.all(X.unsqueeze(1) > vmin[None,...], dim=2) # (npts, 1, 3) > (1, ntpc, 3)
+        c1 = torch.all(X.unsqueeze(1) < vmax[None,...], dim=2) # (npts, 1, 3) < (1, ntpc, 3)
+        cond = c0 & c1
+        #FIXME: assume there is no overlaps
+        indices = torch.nonzero(cond, as_tuple=True)
+        labelc[indices[0]] = indices[1].to(index_dtype)
+        labels.append(labelc)
+    labels = torch.concatenate(labels, dim=0)
+    return labels
+
+def check_features(features):
+    '''
+    The feature array is assumed to be a list of ntuple, with (Tensor[float32], Tensor[float64], Tensor[int32]).
+    The first dimension of each tensor is batch dimension.
+    '''
+    msg = r'features for TPCDataset must a tuple/list consiting of Tensor[float32], Tensor[float64], Tensor[int32].'
+    if not isinstance(features, (tuple,list)):
+        raise ValueError(f'{msg} Type of features is {type(features)}.')
+    if len(features) != 3:
+        raise ValueError(f'{msg} Length of features is {len(features)}.')
+    for i, (f, dtype) in enumerate(zip(features, [torch.float32, torch.float64, torch.int32])):
+        if f.dtype != dtype:
+            raise ValueError(f'{msg} Data type {f.dtype} of features[{i}] does not match {dtype}')
+    return
+
+class TPCDataset(Dataset):
+    '''
+    The feature array is assumed to be a list of ntuple, with (Tensor[float32], Tensor[float64], Tensor[int32]).
+    The first dimension of each tensor is batch dimension.
+    The label array is an integer array for entry labels and TPC labels. TPC labels are optional.
+    '''
+    def __init__(self, features, labels, tpc_id, tpc_label_index=None, sort_index=None):
+        '''
+        `features` and `labels` are selected according to tpc_id if `labels` consists of the TPC labels as the second label.
+        Otherwise, all data in `features` and `labels` are saved.
+        Args:
+            features: tuple/list of tensor.
+            labels: tensor, (N_batch, m) with (label, other_labels, ..., tpclabel) per entry or (N_batch, ) with (label,) per entry
+                     Note: the tpc_label_index should not be used when labels.dim() == 1.
+            tpc_id: scalar
+            tpc_label_index, tpclabels are labels[:,tpclabel_index]
+        '''
+
+        check_features(features)
+
+        if labels.dim() != 1 and tpc_label_index != None:
+            mask = torch.nonzero(labels[:,tpc_label_index] == tpc_id, as_tuple=True)
+            features = [f[mask] for f in features]
+            labels = labels[mask]
+        else:
+            tpc_label_index = None
+
+        if sort_index != None:
+            sort_label = None
+            if sort_index is True and label.dim() == 1:
+                sort_label = label
+            elif isinstance(sort_index, int):
+                sort_label = label[:, sort_index]
+            else:
+                raise ValueError
+            if sort_label != None:            
+                indices = torch.argsort(labels, stable=True)
+                labels = labels[indices]
+                features = [f[indices] for f in  features]
+
+        self.features = features
+        if tpc_label_index is None:
+            self.labels = labels
+        else:
+            col_to_remove = tpc_label_index % labels.shape[1]
+            self.labels = labels[:, torch.arange(labels.shape[1]) != col_to_remove]
+
+        self.length = len(self.labels)
+        self.tpc_id = tpc_id
+
+    def __getitem__(self, idx):
+        return (self.features[0][idx], self.features[1][idx], self.features[2][idx]), self.labels[idx]
+
+    def __len__(self):
+        return self.length
+
+def create_tpc_datasets_from_steps(features, labels, borders, **kwargs):
+    '''
+    features is a list of (Tensor[float32], Tensor[float64], Tensor[int32]).
+    steps is a Tensor[float32], with (N_batch, 8). It corresponds to `StepLoader.__getitem__`.
+    '''
+    check_features(features)
+    steps = features[0]
+    if steps.size(1) != 8:
+        raise ValueError('steps must be a size of (N_batch, 8). Please check `StepLoader`.')
+    X0, X1 = steps[:,2:5], steps[:,5:8]
+    tpclabels = tpc_label(borders, X0, X1, **kwargs)
+    unique_labels, inverse_indices = torch.unique(tpclabels, return_inverse=True, return_counts=False, sorted=True)
+    tpcs = []
+    for tpclabel in unique_labels:
+        if tpclabel < 0:
+            continue
+        indices = torch.nonzero(inverse_indices == tpclabel, as_tuple=True)
+        tpcs.append(TPCDataset(
+            tuple(f[indices] for f in features), labels[indices], tpclabel
+        ))
+    return tpcs
+
+
+class LazyLabelBatchSampler(Sampler):
+    '''
+    Data partition are lazily evaluated at the iterations.
+    A loop on dataset is executed internally per batch.
+    '''
+    def __init__(self, labels, batch_size):
+        self.labels = labels
+        self.batch_size = batch_size
+
+    def __iter__(self):
+        current_label = None
+        batch = []
+        for idx, label in enumerate(self.labels):
+            if current_label is None:
+                current_label = label
+            if label != current_label:
+                for i in range(0, len(batch), self.batch_size):
+                    yield batch[i:i + self.batch_size]
+                batch = []
+                current_label = label
+            batch.append(idx)
+        for i in range(0, len(batch), self.batch_size):
+            yield batch[i:i + self.batch_size]
+    def __len__(self):
+        return len(self.__iter__())
+
+
+class EagerLabelBatchSampler(Sampler):
+    '''
+    Data partition are eagerly evaluated at the initializations.
+    '''
+    def __init__(self, labels, batch_size):
+        self.batch_size = batch_size
+        self.batches = []
+
+        # Precompute batches per group: each batch contains indices with the same label.
+        unique_labels, inverse_indices = torch.unique(labels, sorted=True, return_inverse=True, return_counts=False)
+        # Group indices by label (assuming labels are already ordered)
+        for i, label in enumerate(unique_labels):
+            indices = torch.nonzero(inverse_indices == i, as_tuple=True) # tuple of indices for advanced indexing
+            assert len(indices) == 1
+            for j in range(0, len(indices[0]), self.batch_size):
+                self.batches.append(indices[0][j:j+batch_size])
+    
+    def __iter__(self):
+        # Optionally, shuffle the batches if needed
+        return iter(self.batches)
+
+
+class SortedLabelBatchSampler(Sampler):
+    '''
+    Labels are sorted and features are reordered due to labels.
+    Features are grouped by sorted labels at first eagerly.
+    Lazy evaluations inside group.
+    '''
+    def __init__(self, labels, batch_size):
+        self.batch_size = batch_size
+        self.groups = []
+        idxs = torch.arange(len(labels))
+        unique_labels, inverse_indices = torch.unique(labels, sorted=True, return_inverse=True, return_counts=False)
+        # Group indices by label (assuming labels are already ordered)
+        for i, label in enumerate(unique_labels):
+            indices = torch.nonzero(inverse_indices == i, as_tuple=True) # tuple of indices for advanced indexing
+            assert len(indices) == 1
+            self.groups.append(indices[0]) # indices along batch should be 1D
+            
+    def __iter__(self):
+        for g in self.groups:
+            for i in range(0, len(g), self.batch_size):
+                yield g[i:i+self.batch_size]
+
+    def __len__(self):
+        return len(self.__iter__())
+
+        
+def nd_collate_fn(batch):
+    '''
+    `batch` is assumed to be (features, labels)
+    NOT [(features_sample1, labels_sample1), (features_sample2, labels_sample2), ...].
+    
+    This function does task different from general collate_fn.
+    In general, collate_fn is expected to convert [(features_sample1, labels_sample1), ...]
+    to ([features_sample1, ...], [labels_sample1, ...]).
+    
+    This function will convert time of creation to global + offset.
+
+    `Features` is a list/tuple, (FloatTensor, DoubleTensor, IntTensor)
+
+    Tensors are in a shape of (N_batch, n_feature)
+
+    The time of creation is assumed to be the first component of DoubleTensor.
+    '''        
+    features, labels = batch
+    # features, labels = zip(*batch) # for generatel conversion from [(features_sample1, labels_sample1), ...] to ([features_sample1, ...], [labels_sample1, ...])
+    t64bit = features[1] if features[1].dim() == 1 else features[1][:,0]
+
+    t = torch.min(t64bit, dim=0)[0]
+    t = t.expand(t64bit.size())
+    dt = t64bit - t
+    ts = torch.stack([t.to(torch.float32), dt.to(torch.float32)], dim=1)
+    features = (torch.concatenate([features[0], ts], dim=1), features[1], features[2])
+    
+    return features, labels
+
+
+class CustomNDLoader():
+    '''
+    Dataset must be map-style, having method __getitem__().
+    '''
+    def __init__(self, dataset, sampler=None, collate_fn=None, batch_size=None):
+        '''
+        The loader is not supposed to have automatic batching.
+        
+        It can only support a fixed batch size from `batch_size`, or a batch scheme provided by `sampler`.
+        Arguments `sampler` and `batch_size` are mutually exclusive.
+        
+        Dataset must be map-style, having method __getitem__().
+
+        Argument `collate_fn` is not in the general sense. It does not collect and combine but do transformation on the fly.
+        In the original PyTorch way, collate_fn is expected to convert [(features_sample1, labels_sample1), ...]
+        to ([features_sample1, ...], [labels_sample1, ...]). This function skip the step but assuming data that will be processed 
+        already in the foramt of ([features_sample1, ...], [labels_sample1, ...]) and perform further transformation.
+
+        When sampler is given, `CustomNDLoader(dataset, sampler=sampler, collate_fn=collate_fn)` is expected to behave like
+        `DataLoader(dataset, sampler=sampler, collate_fn=collate_fn, batch_size=None)` (not tested).
+        There is no equivalent in `DataLoader` of PyTorch for `CustomNDLoader(dataset, collate_fn=collate_fn, batch_size=16)`.
+        '''
+        if sampler !=None and batch_size != None:
+            raise ValueError('Wrong argument combination.'
+                             ' Does not support sampler and batch_size simultaneously.'
+                             ' This is not like data loader in PyTorch.')
+        self._dataset = dataset
+        self._sampler = sampler
+        if collate_fn is None:
+            collate_fn = CustomNDLoader.__dummy_collate_fn
+        self._collate_fn = collate_fn
+        self._batch_size = batch_size
+
+    @staticmethod
+    def __dummy_collate_fn(batch):
+        return batch
+
+    def __iter__(self):
+        if self._sampler is None:
+            for i in range(0, len(self._dataset), self._batch_size):
+                yield self._collate_fn(self._dataset[i:i+self._batch_size])
+        else:
+            for indices in self._sampler:
+                yield self._collate_fn(self._dataset[indices])

--- a/src/tred/io_nd.py
+++ b/src/tred/io_nd.py
@@ -305,7 +305,8 @@ def nd_collate_fn(batch):
     # features, labels = zip(*batch) # for generatel conversion from [(features_sample1, labels_sample1), ...] to ([features_sample1, ...], [labels_sample1, ...])
     t64bit = features[1] if features[1].dim() == 1 else features[1][:,0]
 
-    t = torch.min(t64bit, dim=0)[0]
+    # FIXME: decimals to round depends on the units. Here -3 means ms in as I assume t64bit in us.
+    t = torch.min(t64bit, dim=0)[0].round(decimals=-3)
     t = t.expand(t64bit.size())
     dt = t64bit - t
     ts = torch.stack([t.to(torch.float32), dt.to(torch.float32)], dim=1)

--- a/src/tred/loaders.py
+++ b/src/tred/loaders.py
@@ -203,12 +203,14 @@ def steps_from_ndh5(data, type_map=None):
     _dkeys = {
             'float32' : ['dE', 'dEdx', 'x_start', 'y_start', 'z_start', 'x_end', 'y_end', 'z_end'],
             'float64' : ['t0_start'],
-            'int32' : ['event_id', 'pdg_id'] # fixme: event_id is in uint32 at ND
+            'int32' : ['event_id', 'vertex_id', 'pdg_id'] # fixme: event_id is in uint32 at ND
     }
 
     _data = {}
     for k, v in _dkeys.items():
-        _data[k] = torch.stack([torch.tensor(data[n], dtype=type_map[k], requires_grad=False) for n in v], dim=1) \
+        # FIXME: check data[n].flags['C_CONTIGUOUS']) and force to convert to contiguous array
+        # data[n] = np.ascontiguousarray(data[n])
+        _data[k] = torch.stack([torch.tensor(data[n].copy(), dtype=type_map[k], requires_grad=False) for n in v], dim=1) \
             if isinstance(v, (list, tuple)) else torch.tensor(data[v], dtype=type_map[k], requires_grad=False)
 
     return _dkeys, _data

--- a/tests/effq/test_raster_steps.py
+++ b/tests/effq/test_raster_steps.py
@@ -1,0 +1,50 @@
+import sys
+import numpy as np
+
+import torch
+import logging
+import tred.graph as tg
+
+def test_compute_qeff_raster_steps(level=None):
+    local_logger = logging.getLogger('test_eval_qeff_raster_steps')
+    if level:
+        local_logger.setLevel(level)
+
+    # Test the raster_steps wrapper. Note: raster_steps uses fixed npoints=(2,2,2)
+    grid_spacing = (0.1, 0.1, 0.1)
+    tail = torch.tensor([(0.4, 2.4, 3.4)])
+    head = torch.tensor([(0.6, 2.6, 3.6)])
+    sigma = torch.tensor([(0.5, 0.5, 0.5)])
+    charge = torch.tensor([(1,)])
+    nsigma = 0.7
+
+    effq, offset = tg.raster_steps(grid_spacing, tail, head, sigma, charge, nsigma=nsigma)
+
+    q_sum = torch.sum(effq).item()
+    qint = 0.313723 # from mathematica
+    local_logger.debug(f'Raster steps test passed, computed integral sum: {q_sum}')
+    assert q_sum > 0, "Raster steps computed integral should be positive"
+    assert np.isclose(q_sum, qint, rtol=1E-5), f'Raster steps computed integral does not match predefined value {qint}.'
+
+def main():
+    print('-------- test_compute_qeff ---------')
+    test_compute_qeff_raster_steps()
+
+
+if __name__ == '__main__':
+    try:
+        opt = sys.argv[1]
+        if opt.lower() == 'debug':
+            logging.basicConfig(level=logging.DEBUG)
+        elif opt.lower() == 'warning':
+            logging.basicConfig(level=logging.WARNING)
+        elif opt.lower() == 'info':
+            logging.basicConfig(level=logging.INFO)
+        else:
+            print('Usage: test_grid.py [debug|warning|info]')
+            exit(-1)
+    except IndexError:
+        # logging.basicConfig(level=logging.DEBUG)
+        print('To use system default logging level')
+
+    main()

--- a/tests/effq/test_raster_steps.py
+++ b/tests/effq/test_raster_steps.py
@@ -1,5 +1,6 @@
 import sys
 import numpy as np
+import matplotlib.pyplot as plt
 
 import torch
 import logging
@@ -50,13 +51,112 @@ def test_transform(level=None):
     p = raster._transform(points, time)
     assert p.equal(torch.tensor([3, 2, 5]).view(1,3)), f'points after transformation is {p}.'
 
+def test_time_diff():
+    """Test the _time_diff method.
+        Test _time_diff with head as None."""
+    velocity = 2.0
+    grid_spacing = torch.tensor([0.5])
+    raster = tg.Raster(velocity, grid_spacing, pdims=())
+    tail = torch.tensor([0.0, 1.0, 2.0])
+    head = torch.tensor([2.0, 3.0, 4.0])
+    result = raster._time_diff(tail, head)
+    expected = (tail - head) / velocity
+    assert torch.equal(result, expected), f"expected {expected}, result {result}"
+
+    grid_spacing = torch.tensor([0.5, 0.5, 0.5])
+    raster = tg.Raster(velocity, grid_spacing, pdims=(1,2))
+    tail = torch.tensor([[0.0, 1.0, 2.0]])
+    head = torch.tensor([[2.0, 3.0, 4.0]])
+    result = raster._time_diff(tail, head)
+    expected = (tail[:,0]-head[:,0]) / velocity
+    assert torch.equal(result, expected)
+
+    result = raster._time_diff(torch.tensor([1.0, 2.0, 3.0]))
+    assert result is None
+
+
+def test_drift_raster_positions():
+    # Define parameters
+    time = 1
+    charge = torch.tensor([10, 10])# Placeholder value
+    target = 3
+    velocity = 2.0
+    drifter = tg.Drifter(diffusion=[0.1, 0.1], lifetime=10, velocity=velocity, target=target)
+
+    tail = torch.tensor([[1, 2], [-1, 1]])
+    head = tail.clone().detach()
+    head[:,0] = head[:,0] - 1
+    head[:,1] = head[:,1] - 2
+    _, dtime, _, dtail, dhead = drifter(time, charge, tail, head)
+
+    # Create the plot
+    # plt.figure(figsize=(8, 6))
+    nrows = 2
+    ncols = 1
+    fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=(8*ncols, 6*nrows))
+
+    # Plot Raster data points
+    for i in range(tail.size(0)):
+        if i == 0:
+            axes[0].plot(tail[i,0], tail[i,1], color='blue', label='tail', marker='o', linestyle='-')
+            axes[0].plot(head[i,0], head[i,1], color='red', label='head', marker='o', linestyle='-')
+            axes[0].plot(dtail[i,0], dtail[i,1], color='blue', label='dtail', marker='x', linestyle='-')
+            axes[0].plot(dhead[i,0], dhead[i,1], color='red', label='dhead', marker='x', linestyle='-')
+        else:
+            axes[0].plot(tail[i,0], tail[i,1], color='blue', marker='o', linestyle='-')
+            axes[0].plot(head[i,0], head[i,1], color='red', marker='o', linestyle='-')
+            axes[0].plot(dtail[i,0], dtail[i,1], color='blue', marker='x', linestyle='-')
+            axes[0].plot(dhead[i,0], dhead[i,1], color='red', marker='x', linestyle='-')
+        axes[0].plot([tail[i,0], head[i,0]], [tail[i, 1], head[i,1]], 'k--')
+        axes[0].plot([dtail[i,0], dhead[i,0]], [dtail[i, 1], dhead[i,1]], 'k--')
+    axes[0].vlines([target,], -2, 4, label='target')
+
+    grid_spacing = torch.tensor([0.5, 0.5, 0.5])
+    raster = tg.Raster(velocity, grid_spacing, pdims=(1,2))
+    ttail = dtime
+    thead = ttail + raster._time_diff(dtail, dhead)
+
+    for i in range(tail.size(0)):
+        if i == 0:
+            axes[1].plot(time, tail[i,1], color='blue', label='tail', marker='o', linestyle='-')
+            axes[1].plot(time, head[i,1], color='red', label='head', marker='o', linestyle='-')
+            axes[1].plot(ttail[i], dtail[i,1], color='blue', label='dtail', marker='x', linestyle='-')
+            axes[1].plot(thead[i], dhead[i,1], color='red', label='dhead', marker='x', linestyle='-')
+        else:
+            axes[1].plot(time, tail[i,1], color='blue', marker='o', linestyle='-')
+            axes[1].plot(time, head[i,1], color='red', marker='o', linestyle='-')
+            axes[1].plot(ttail[i], dtail[i,1], color='blue', marker='x', linestyle='-')
+            axes[1].plot(thead[i], dhead[i,1], color='red', marker='x', linestyle='-')
+        axes[1].plot([time, time], [tail[i, 1], head[i,1]], 'k--')
+        axes[1].plot([ttail[i], thead[i]], [dtail[i, 1], dhead[i,1]], 'k--')
+    axes[1].vlines([time,], -2, 4, label='initial time')
+
+    # Labels and legend
+    axes[0].set_xlabel("X-axis")
+    axes[0].set_ylabel("Y-axis")
+    axes[0].set_title("Tail, Head, before and after drifting")
+    axes[0].legend()
+    axes[0].grid(True)
+
+    axes[1].set_xlabel("Time")
+    axes[1].set_ylabel("Y-axis")
+    axes[1].set_title("Tail, Head, before and after driting")
+    axes[1].legend()
+    axes[1].grid(True)
+
+    # Show the plot
+    plt.savefig('drifted_tailhead.png')
 
 def main():
-    print('-------- test_compute_qeff ---------')
+    # print('-------- test_compute_qeff ---------')
     test_compute_qeff_raster_steps()
 
-    print('-------- test_transform ---------')
+    # print('-------- test_transform ---------')
     test_transform()
+
+    test_time_diff()
+
+    test_drift_raster_positions()
 
 if __name__ == '__main__':
     try:

--- a/tests/effq/test_raster_steps.py
+++ b/tests/effq/test_raster_steps.py
@@ -51,6 +51,14 @@ def test_transform(level=None):
     p = raster._transform(points, time)
     assert p.equal(torch.tensor([3, 2, 5]).view(1,3)), f'points after transformation is {p}.'
 
+    points = torch.tensor([3,4,5]).view(1,3)
+    time = torch.tensor([2])
+    pdims = (0, 2)
+    tdim = -1
+    raster = tg.Raster(velocity=0.16, grid_spacing=(1,1,1), pdims=pdims, tdim=tdim, nsigma=3.0)
+    p = raster._transform(points, time)
+    assert p.equal(torch.tensor([3, 5, 2]).view(1,3)), f'points after transformation is {p}.'
+
 def test_time_diff():
     """Test the _time_diff method.
         Test _time_diff with head as None."""

--- a/tests/effq/test_raster_steps.py
+++ b/tests/effq/test_raster_steps.py
@@ -5,8 +5,10 @@ import torch
 import logging
 import tred.graph as tg
 
+logger = logging.getLogger('tred/tests/effq/test_raster_steps.py')
+
 def test_compute_qeff_raster_steps(level=None):
-    local_logger = logging.getLogger('test_eval_qeff_raster_steps')
+    local_logger = logger.getChild('test_eval_qeff_raster_steps')
     if level:
         local_logger.setLevel(level)
 
@@ -26,10 +28,35 @@ def test_compute_qeff_raster_steps(level=None):
     assert q_sum > 0, "Raster steps computed integral should be positive"
     assert np.isclose(q_sum, qint, rtol=1E-5), f'Raster steps computed integral does not match predefined value {qint}.'
 
+def test_transform(level=None):
+    local_logger = logger.getChild('test_transform')
+    if level:
+        local_logger.setLevel(level)
+    local_logger.debug('Testing transform by predefined values')
+
+    points = torch.tensor([3,4,5]).view(1,3)
+    time = torch.tensor([2])
+    pdims = (1, 2)
+    tdim = 1
+    raster = tg.Raster(velocity=0.16, grid_spacing=(1,1,1), pdims=pdims, tdim=tdim, nsigma=3.0)
+    p = raster._transform(points, time)
+    assert p.equal( torch.tensor([4, 2, 5]).view(1,3) ),  f'points after transformation is {p}.'
+
+    points = torch.tensor([3,4,5]).view(1,3)
+    time = torch.tensor([2])
+    pdims = (0, 2)
+    tdim = 1
+    raster = tg.Raster(velocity=0.16, grid_spacing=(1,1,1), pdims=pdims, tdim=tdim, nsigma=3.0)
+    p = raster._transform(points, time)
+    assert p.equal(torch.tensor([3, 2, 5]).view(1,3)), f'points after transformation is {p}.'
+
+
 def main():
     print('-------- test_compute_qeff ---------')
     test_compute_qeff_raster_steps()
 
+    print('-------- test_transform ---------')
+    test_transform()
 
 if __name__ == '__main__':
     try:

--- a/tests/nd_loader/test_io_dataset.py
+++ b/tests/nd_loader/test_io_dataset.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# In[1]:
+
+
+import sys
+import h5py
+import numpy as np
+import yaml
+from collections import defaultdict
+import torch
+import time
+
+from torch.utils.data import DataLoader
+
+
+# In[2]:
+
+
+import sys
+sys.path.append('/home/yousen/Documents/NDLAr2x2/tred/src')
+from tred.types import index_dtype
+
+from tred.units import cm, mm
+
+from importlib import reload  # Python 3.4+
+import tred.loaders
+
+tred.loaders = reload(tred.loaders)
+
+from tred.loaders import StepLoader, steps_from_ndh5
+
+import tred.io_nd
+
+tred.io_nd = reload(tred.io_nd)
+
+from tred.io_nd import (
+    nd_collate_fn, create_tpc_datasets_from_steps,
+    LazyLabelBatchSampler, EagerLabelBatchSampler, SortedLabelBatchSampler, CustomNDLoader, simple_geo_parser
+)
+
+
+# In[3]:
+
+
+borders = simple_geo_parser('../nd_geometry/ndlar-module.yaml', '../nd_geometry/multi_tile_layout-3.0.40.yaml')
+
+
+# In[4]:
+
+
+path = '/home/yousen/Public/ndlar_shared/data/MicroProdN1p1_NDLAr_1E18_RHC.convert2h5.nu.0000001.EDEPSIM.hdf5'
+d0 = StepLoader(h5py.File(path), transform=steps_from_ndh5)
+
+
+# In[5]:
+
+
+f0, f1, i0 = d0[:]
+tpcs = create_tpc_datasets_from_steps((f0, f1, i0), i0, borders, sort_index=1)
+
+
+# In[6]:
+
+
+def is_correct(tpcdataset, use_collate=False):
+    label_index = 0
+    d0 = {}
+    d1 = {}
+    collate_fn = nd_collate_fn if use_collate else None
+    for btype, sampler in zip(
+        ['lazy', 'sorted', 'eager'], [LazyLabelBatchSampler, SortedLabelBatchSampler, EagerLabelBatchSampler]
+    ):
+        dl0 = DataLoader(tpcdataset, sampler=sampler(tpcdataset.labels[:,label_index], 4096), batch_size=None, collate_fn=collate_fn)
+        dl1 = CustomNDLoader(tpcdataset, sampler=sampler(tpcdataset.labels[:,label_index], 4096), batch_size=None, collate_fn=collate_fn)
+        d0[btype] = [d for d in dl0]
+        d1[btype] = [d for d in dl1]
+
+    for btype in d0.keys():
+        assert len(d0[btype]) == len(d0[btype])
+        for b in d0[btype]:
+            ls = torch.unique(b[1][:,label_index])
+            assert len(ls) == 1
+        l = torch.concat([d[1] for d in d0[btype]], dim=0)
+        # print(btype, len(tpcdataset.labels.equal(torch.concat([d[1] for d in d0[btype]], dim=0))))
+        assert tpcdataset.labels.equal(torch.concat([d[1] for d in d0[btype]], dim=0))
+        assert tpcdataset.labels.equal(torch.concat([d[1] for d in d1[btype]], dim=0))
+
+        for i in range(3):
+            s = (slice(None,None,None), slice(0,8,None)) if i == 0 else slice(None,None,None)
+            assert tpcdataset.features[i].allclose(torch.concat([d[0][i][s] for d in d0[btype]], dim=0))
+            assert tpcdataset.features[i].allclose(torch.concat([d[0][i][s] for d in d1[btype]], dim=0))
+    if use_collate:
+        for i in range(3):
+            print(d0[btype][i][0][0][:3,8:], 'sum', torch.sum(d0[btype][i][0][0][:3,8:].to(torch.float64), dim=1), d0[btype][i][0][1][:3])
+
+
+# In[7]:
+
+
+is_correct(tpcs[1])
+is_correct(tpcs[1], True)
+
+
+# In[8]:
+
+
+stime = time.time()
+loader = DataLoader(tpcs[0], sampler=LazyLabelBatchSampler(tpcs[0].labels[:,1], 4096), batch_size=None)
+nelements = 0
+for batch_idx, (features, label_batch) in enumerate(loader):
+    nelements += len(features[0])
+etime = time.time()
+print(etime - stime)
+
+
+# In[9]:
+
+
+stime = time.time()
+loader = CustomNDLoader(tpcs[0], sampler=LazyLabelBatchSampler(tpcs[0].labels[:,1], 4096), batch_size=None)
+nelements = 0
+for batch_idx, (features, label_batch) in enumerate(loader):
+    nelements += len(features[0])
+etime = time.time()
+print(nelements)
+print(etime - stime)
+
+
+# In[10]:
+
+
+stime = time.time()
+batch_sampler = SortedLabelBatchSampler(tpcs[0].labels[:,1], 4096)
+loader = CustomNDLoader(tpcs[0], sampler=batch_sampler)
+nelements = 0
+for batch_idx, (features, label_batch) in enumerate(loader):
+    nelements += len(features[0])
+etime = time.time()
+print(nelements)
+print(etime - stime)
+
+
+# In[11]:
+
+
+for itpc in range(len(tpcs)):
+    loader = CustomNDLoader(tpcs[itpc], sampler=LazyLabelBatchSampler(tpcs[itpc].labels[:,1], 4096), batch_size=None)
+    nelements = 0
+    stime = time.time()
+    for batch_idx, (features, label_batch) in enumerate(loader):
+        nelements += len(features[0])
+    etime = time.time()
+    print(itpc, etime - stime, nelements, (etime-stime)/nelements * 1E9)
+
+
+# In[12]:
+
+
+for itpc in range(len(tpcs)):
+    loader = CustomNDLoader(tpcs[itpc], sampler=SortedLabelBatchSampler(tpcs[itpc].labels[:,1], 4096), batch_size=None)
+    nelements = 0
+    stime = time.time()
+    for batch_idx, (features, label_batch) in enumerate(loader):
+        nelements += len(features[0])
+    etime = time.time()
+    print(itpc, etime - stime, nelements, 'average time per elements in the batch (ns)', (etime-stime)/nelements * 1E9)
+
+
+# In[13]:
+
+
+stime = time.time()
+loader = CustomNDLoader(tpcs[0], sampler=EagerLabelBatchSampler(tpcs[0].labels[:,1], 4096), batch_size=None)
+nelements = 0
+for batch_idx, (features, label_batch) in enumerate(loader):
+    nelements += len(features[0])
+etime = time.time()
+print(nelements)
+print(etime - stime)
+
+
+# In[14]:
+
+
+for itpc in range(len(tpcs)):
+    loader = CustomNDLoader(tpcs[itpc], sampler=EagerLabelBatchSampler(tpcs[itpc].labels[:,1], 4096), batch_size=None)
+    nelements = 0
+    stime = time.time()
+    for batch_idx, (features, label_batch) in enumerate(loader):
+        nelements += len(features[0])
+    etime = time.time()
+    print(itpc, etime - stime, nelements, (etime-stime)/nelements * 1E9)
+
+
+# In[15]:
+
+
+for itpc in range(len(tpcs)):
+    loader = DataLoader(tpcs[itpc], sampler=EagerLabelBatchSampler(tpcs[itpc].labels[:,1], 4096), batch_size=None)
+    nelements = 0
+    stime = time.time()
+    for batch_idx, (features, label_batch) in enumerate(loader):
+        nelements += len(features[0])
+    etime = time.time()
+    print(itpc, etime - stime, nelements, (etime-stime)/nelements * 1E9)
+
+
+# In[16]:
+
+
+for itpc in range(len(tpcs)):
+    loader = CustomNDLoader(tpcs[itpc], sampler=SortedLabelBatchSampler(tpcs[itpc].labels[:,1], 4096), batch_size=None)
+    nelements = 0
+    stime = time.time()
+    for batch_idx, (features, label_batch) in enumerate(loader):
+        nelements += len(features[0])
+    etime = time.time()
+    print(itpc, etime - stime, nelements, (etime-stime)/nelements * 1E9)
+
+
+# In[17]:
+
+
+for itpc in range(len(tpcs)):
+    loader = CustomNDLoader(tpcs[itpc], sampler=SortedLabelBatchSampler(tpcs[itpc].labels[:,1], 4096), batch_size=None,
+                           collate_fn=nd_collate_fn)
+    nelements = 0
+    stime = time.time()
+    for batch_idx, (features, label_batch) in enumerate(loader):
+        nelements += len(features[0])
+    etime = time.time()
+    print(itpc, etime - stime, nelements, (etime-stime)/nelements * 1E9)
+
+
+# In[18]:
+
+
+for itpc in range(len(tpcs)):
+    loader = CustomNDLoader(tpcs[itpc], sampler=None, batch_size=4096)
+    nelements = 0
+    stime = time.time()
+    for batch_idx, (features, label_batch) in enumerate(loader):
+        nelements += len(features[0])
+    etime = time.time()
+    print(itpc, etime - stime, nelements, (etime-stime)/nelements * 1E9)
+
+
+# In[19]:
+
+
+for itpc in range(len(tpcs)):
+    loader = CustomNDLoader(tpcs[itpc], sampler=None, batch_size=4096)
+    nelements = 0
+    stime = time.time()
+    for batch_idx, (features, label_batch) in enumerate(loader):
+        nelements += len(features[0])
+    etime = time.time()
+    print(itpc, etime - stime, nelements, (etime-stime)/nelements * 1E9)
+
+
+# In[ ]:
+
+
+
+

--- a/tests/test_steploader.py
+++ b/tests/test_steploader.py
@@ -72,8 +72,8 @@ def plot_segments(fpath):
 
 def test_special_numbers():
     data = [
-        (1, 2, 1,1,1,2,4,9, 1, 1),
-        (1, 1, 2,4,9,2,4,10, 1, 2)
+        (1, 2, 1,1,1,2,4,9, 1, 1, 20),
+        (1, 1, 2,4,9,2,4,10, 1, 2, 20)
     ]
 
     X0X1 = np.array(data)[:,2:8].astype(np.float32)
@@ -86,11 +86,14 @@ def test_special_numbers():
     pdg_id = torch.tensor(pdg_id)
     event_id = np.array(data)[:,9].astype(np.int32)
     event_id = torch.tensor(event_id)
+    t0_start = np.array(data)[:,10].astype(np.float64)
+    t0_start = torch.tensor(t0_start)
+    dummy = torch.empty((len(t0_start),0), dtype=torch.float64)
 
     dtype = np.dtype([('dE', 'f4'), ('dEdx', 'f4'), ('x_start', 'f4'),
                       ('y_start', 'f4'), ('z_start', 'f4'), ('x_end', 'f4'),
                       ('y_end', 'f4'), ('z_end', 'f4'),
-                      ('pdg_id', 'i4'), ('event_id', 'i4')])
+                      ('pdg_id', 'i4'), ('event_id', 'i4'), ('t0_start', 'f8')])
 
     data = np.array(data, dtype=dtype)
 
@@ -102,22 +105,24 @@ def test_special_numbers():
     print('Test _equal_div')
     Ns = (torch.linalg.norm(X0X1[:,:3]-X0X1[:,3:], dim=1)//step_limit)\
         .to(torch.int32) + 1
-    X0X1_, dE_, dEdx_, intids_ = (
-        _equal_div_script(X0X1, dE, dEdx,
-                          torch.stack([pdg_id, event_id], dim=1).view(-1, 2),
+    X0X1_, dE_, dEdx_, dummy_, ts_, intids_ = (
+        _equal_div_script(X0X1, dE, dEdx, dummy, t0_start,
+                          torch.stack([event_id, pdg_id], dim=1).view(-1, 2),
                           Ns)
     )
 
     print('Test _batch_equal_div')
-    _X0X1, _dE, _dEdx, _intids = (
-        StepLoader._batch_equal_div(X0X1, dE, dEdx,
-                                    torch.stack([pdg_id, event_id], dim=1).view(-1, 2),
+    _X0X1, _dE, _dEdx, _dummy, _ts, _intids = (
+        StepLoader._batch_equal_div(X0X1, dE, dEdx, dummy, t0_start,
+                                    torch.stack([event_id, pdg_id], dim=1).view(-1, 2),
                                     step_limit, mem_limit=1/1024/1024,
                                     fn=_equal_div_script)
     )
     assert X0X1_.allclose(_X0X1)
     assert dE_.allclose(_dE)
     assert dEdx_.allclose(_dEdx)
+    assert ts_.allclose(_ts)
+    assert dummy_.allclose(_dummy)
     assert intids_.allclose(_intids)
 
     data = StepLoader(data, step_limit=step_limit, transform=steps_from_ndh5)
@@ -128,14 +133,15 @@ def test_special_numbers():
         dL =torch.linalg.norm(X0-X1)
         dE = data[i][0][0]
         dEdx = data[i][0][1]
-        intids = data[i][1]
-        print(data[i], dL)
+        ts = data[i][1]
+        intids = data[i][2]
         assert dL < step_limit
         assert X0.allclose(X0X1_[i,:3])
         assert X1.allclose(X0X1_[i,3:])
         assert dE.allclose(dE_[i])
         assert dEdx.allclose(dEdx_[i])
-        assert intids.allclose(intids_[i])
+        assert ts.allclose(ts_[i])
+        assert intids.equal(intids_[i])
         if i>0:
             assert data[i][0][2:5].allclose(data[i-1][0][5:8])
 
@@ -216,12 +222,15 @@ def test_perf():
     data['float32'] = torch.stack([torch.tensor(segments[n], requires_grad=False)
                                    for n in ['dE', 'dEdx', 'x_start', 'y_start',
                                              'z_start', 'x_end', 'y_end', 'z_end']], dim=1)
+    data['float64'] = torch.tensor(segments['t0_start'])
     data['int32'] = torch.stack([torch.tensor(segments[n], dtype=torch.int32,
                                               requires_grad=False)
                                  for n in ['pdg_id', 'event_id']], dim=1)
     X0X1 = data['float32'][:,2:8]
     dE = data['float32'][:,0]
     dEdx = data['float32'][:,1]
+    ExtensiveDouble = torch.empty((len(dE),0), dtype=torch.float64, requires_grad=False)
+    IntensiveDouble = data['float64']
     IntensiveInt = data['int32']
     step_limit = 1
     mem_limit = 5*1024 # MB
@@ -230,7 +239,7 @@ def test_perf():
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
     start.record()
-    StepLoader._batch_equal_div(X0X1, dE, dEdx, IntensiveInt,
+    StepLoader._batch_equal_div(X0X1, dE, dEdx, ExtensiveDouble, IntensiveDouble, IntensiveInt,
                                     step_limit, mem_limit, device='cuda',
                                 fn=_equal_div_script)
     torch.cuda.synchronize()
@@ -246,11 +255,11 @@ def test_perf():
     mem_limit = 5*1024 # MB
     print('Warm up on CPU-GPU-CPU')
     for i in range(5):
-        StepLoader._batch_equal_div(X0X1, dE, dEdx, IntensiveInt,
+        StepLoader._batch_equal_div(X0X1, dE, dEdx, ExtensiveDouble, IntensiveDouble, IntensiveInt,
                                     step_limit, mem_limit, device='cuda',
                                     fn=_equal_div_script)
     start = time.time()
-    StepLoader._batch_equal_div(X0X1, dE, dEdx, IntensiveInt,
+    StepLoader._batch_equal_div(X0X1, dE, dEdx, ExtensiveDouble, IntensiveDouble, IntensiveInt,
                                 step_limit, mem_limit, device='cuda',
                                 fn=_equal_div_script)
     end = time.time()
@@ -263,16 +272,18 @@ def test_perf():
 
     dE = dE.to('cuda:0')
     dEdx = dEdx.to('cuda:0')
+    ExtensiveDouble = ExtensiveDouble.to('cuda:0')
+    IntensiveDouble = IntensiveDouble.to('cuda:0')
     IntensiveInt = IntensiveInt.to('cuda:0')
     mem_limit = 5*1024 # MB
     print('Warm up on GPU')
     for i in range(5):
-        StepLoader._batch_equal_div(X0X1, dE, dEdx, IntensiveInt,
+        StepLoader._batch_equal_div(X0X1, dE, dEdx, ExtensiveDouble, IntensiveDouble, IntensiveInt,
                                     step_limit, mem_limit, device='cuda',
                                     fn=_equal_div_script)
     torch.cuda.synchronize()
     start = time.time()
-    X0X1new, _, _, _ = StepLoader._batch_equal_div(X0X1, dE, dEdx, IntensiveInt,
+    X0X1new, _, _, _, _, _ = StepLoader._batch_equal_div(X0X1, dE, dEdx, ExtensiveDouble, IntensiveDouble, IntensiveInt,
                                                    step_limit, mem_limit, device='cuda',
                                                    fn = _equal_div_script)
     torch.cuda.synchronize()
@@ -287,6 +298,16 @@ def test_perf():
     print('Elapsed', (end-start)*1000, 'ms for X0X1cpu transfering from C to G to C')
     print('Correction factor', len(X0X1new)/len(X0X1))
 
+
+    torch.cuda.synchronize()
+    ExtensiveDouble = ExtensiveDouble.to('cpu')
+    IntensiveDouble = IntensiveDouble.to('cpu')
+    start = time.time()
+    ExtensiveDouble.to('cuda').to('cpu')
+    IntensiveDouble.to('cuda').to('cpu')
+    torch.cuda.synchronize()
+    end = time.time()
+    print('Elapsed', (end-start)*1000, 'ms for float64 transfering from C to G to C')
 
 if __name__ == '__main__':
     test_special_numbers()


### PR DESCRIPTION
Defined a few test and fixed several bugs.
Improved test coverage and fixed several bugs:

- Post-drift position components are now correctly handled. This is verified in `test_raster_steps.py`.
- Post-drift time for both head and tail is now correctly defined as (tail - head) / velocity + time of tail at anodes. This relationship is illustrated in the plot generated by `test_raster_steps.py`.  
  In coordinate space, the steps stop at the target plane. In the time domain, the tail and head share a common time of creation but have different arrival times at the target plane. The point farther from the plane has a larger post-drift time, as shown in the generated figure.
- Diffusion widths are now properly transformed by swapping components and converting to a time series along the drift direction.
- Effective charges are now calculated. The integral passes the unit test in `test_raster_steps.py`.
